### PR TITLE
Fix: shortenValue always return string

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="591df150-9651-4926-81cc-bff51795dfcc" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/EavesDrop.xml" beforeDir="false" afterPath="$PROJECT_DIR$/EavesDrop.xml" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectId" id="1shb2Ctb2OxqooMbnSsMFFP6TBu" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">
+    <property name="RunOnceActivity.OpenProjectViewOnStart" value="true" />
+    <property name="RunOnceActivity.ShowReadmeOnStart" value="true" />
+    <property name="WebServerToolWindowFactoryState" value="false" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
+    <property name="nodejs_interpreter_path.stuck_in_default_project" value="undefined stuck path" />
+    <property name="nodejs_npm_path_reset_for_default_project" value="true" />
+    <property name="vue.rearranger.settings.migration" value="true" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="591df150-9651-4926-81cc-bff51795dfcc" name="Default Changelist" comment="" />
+      <created>1621327559037</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1621327559037</updated>
+      <workItem from="1621327561487" duration="1452000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/EavesDrop.lua
+++ b/EavesDrop.lua
@@ -154,7 +154,7 @@ local function shortenValue(value)
   elseif value >= 10000 then
     value = string_format("%.1fk",value / 1000)
   end
-  return value
+  return tostring(value)
 end
 
 local function round(num, idp)
@@ -483,9 +483,9 @@ function EavesDrop:CombatEvent()
     if (critical) then text = critchar..text..critchar end
     if (crushing) then text = crushchar..text..crushchar end
     if (glancing) then text = glancechar..text..glancechar end
-    if (resisted) then text = string_format("%s (%d)", text, shortenValue(resisted)) end
-    if (blocked) then text = string_format("%s (%d)", text, shortenValue(blocked)) end
-    if (absorbed) then text = string_format("%s (%d)", text, shortenValue(absorbed))end
+    if (resisted) then text = string_format("%s (%s)", text, shortenValue(resisted)) end
+    if (blocked) then text = string_format("%s (%s)", text, shortenValue(blocked)) end
+    if (absorbed) then text = string_format("%s (%s)", text, shortenValue(absorbed))end
 
     if fromPlayer then
       if (self:TrackStat(inout, "hit", spellName, texture, SCHOOL_STRINGS[school], amount, critical, message)) then
@@ -531,7 +531,7 @@ function EavesDrop:CombatEvent()
     if toPlayer then
       totHealingIn = totHealingIn + amount
       if (amount < db["HFILTER"]) then return end
-      if (db["OVERHEAL"]) and overHeal > 0 then text = string_format("%d {%d}", shortenValue(amount-overHeal), shortenValue(overHeal)) end
+      if (db["OVERHEAL"]) and overHeal > 0 then text = string_format("%s {%s}", shortenValue(amount-overHeal), shortenValue(overHeal)) end
       if (critical) then text = critchar..text..critchar end
       if (db["HEALERID"] == true and not fromPlayer) then text = text.." ("..sourceName..")" end
       color = db["PHEAL"]
@@ -542,7 +542,7 @@ function EavesDrop:CombatEvent()
     elseif fromPlayer then
       totHealingOut = totHealingOut + amount
       if (amount < db["HFILTER"]) then return end
-      if (db["OVERHEAL"]) and overHeal > 0 then text = string_format("%d {%d}", shortenValue(amount-overHeal), shortenValue(overHeal)) end
+      if (db["OVERHEAL"]) and overHeal > 0 then text = string_format("%s {%s}", shortenValue(amount-overHeal), shortenValue(overHeal)) end
       if (critical) then text = critchar..text..critchar end
       color = db["THEAL"]
       if (self:TrackStat(inout, "heal", spellName, texture, SCHOOL_STRINGS[spellSchool], amount, critical, message)) then
@@ -630,7 +630,7 @@ end
 function EavesDrop:PLAYER_XP_UPDATE()
   local xp = UnitXP("player")
   local xpgained = xp - pxp
-  self:DisplayEvent(MISC, string_format("+%d (%s)", shortenValue(xpgained), XP), nil, db["EXPC"], nil)
+  self:DisplayEvent(MISC, string_format("+%s (%s)", shortenValue(xpgained), XP), nil, db["EXPC"], nil)
   pxp = xp
 end
 
@@ -990,7 +990,7 @@ function EavesDrop:ParseReflect(timestamp, event, hideCaster, sourceGUID, source
 
   --reflected events
   if (self.ReflectTarget == sourceName and sourceName == destName and self.ReflectSkill == spellName) then
-    local text = string_format("%s: %d", REFLECT, shortenValue(amount))
+    local text = string_format("%s: %s", REFLECT, shortenValue(amount))
     if (critical) then text = critchar..text..critchar end
     self:DisplayEvent(OUTGOING, text, texture, self:SpellColor(db["TSPELL"], SCHOOL_STRINGS[school]), messsage)
     self:ClearReflect()


### PR DESCRIPTION
Found an issue in the Wotlk beta where `shortenValue` return a string if the value was shortended. But when combining `shortenValue` and `string_format("%d", shortenValue(10000))` for example the `shortenValue` returns a string and the `string_format` would not work.